### PR TITLE
Support for Google Custom Search Engine API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Then add **hubot-google-images** to your `external-scripts.json`:
   "hubot-google-images"
 ]
 ```
+## Configuration
+
+Set environment variables `HUBOT_GOOGLE_CSE_ID` and `HUBOT_GOOGLE_API_KEY` to use the
+[Google Custom Search API](https://developers.google.com/custom-search/docs/overview)
+instead of the deprecated image search API.
 
 ## Sample Interaction
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,16 @@ Then add **hubot-google-images** to your `external-scripts.json`:
   "hubot-google-images"
 ]
 ```
+
 ## Configuration
 
-Set environment variables `HUBOT_GOOGLE_CSE_ID` and `HUBOT_GOOGLE_API_KEY` to use the
-[Google Custom Search API](https://developers.google.com/custom-search/docs/overview)
+Set environment variables `HUBOT_GOOGLE_CSE_ID` and `HUBOT_GOOGLE_CSE_KEY`
+to use the [Google Custom Search API](https://developers.google.com/custom-search/docs/overview)
 instead of the deprecated image search API.
+
+You might want to use the custom search API if you have concerns about
+seeing NSFW images. The old Google image search API only has `safe=active`
+which is not as strict as `safe=strict` on the new API.
 
 ## Sample Interaction
 

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -57,9 +57,8 @@ imageMe = (msg, query, animated, faces, cb) ->
       .query(q)
       .get() (err, res, body) ->
         response = JSON.parse(body)
-        data = response?.responseData
-        if data?.items
-          image = msg.random data.items
+        if response?.items
+          image = msg.random response.items
           cb ensureImageExtension image.link
         else
           msg.send "Oops. I had trouble searching '#{query}'. Try later."

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -2,7 +2,7 @@
 #   A way to interact with the Google Images API.
 #
 # Configuration
-#   HUBOT_GOOGLE_API_KEY - Your developer API key
+#   HUBOT_GOOGLE_CSE_KEY - Your Google developer API key
 #   HUBOT_GOOGLE_CSE_ID - The ID of your Custom Search Engine
 #
 # Commands:
@@ -37,9 +37,11 @@ imageMe = (msg, query, animated, faces, cb) ->
   googleCseId = process.env.HUBOT_GOOGLE_CSE_ID
   if googleCseId
     # Using Google Custom Search API
-    googleApiKey = process.env.HUBOT_GOOGLE_API_KEY
+    googleApiKey = process.env.HUBOT_GOOGLE_CSE_KEY
     if !googleApiKey
-      msg.robot.logger.error "Missing Google API key"
+      msg.robot.logger.error "Missing environment variable HUBOT_GOOGLE_CSE_KEY"
+      msg.send "Missing server environment variable HUBOT_GOOGLE_CSE_KEY."
+      return
     q =
       q: query,
       searchType:'image',
@@ -56,6 +58,12 @@ imageMe = (msg, query, animated, faces, cb) ->
     msg.http(url)
       .query(q)
       .get() (err, res, body) ->
+        if err
+          msg.send "Encountered an error :( #{err}"
+          return
+        if res.statusCode isnt 200
+          msg.send "Bad HTTP response :( #{res.statusCode}"
+          return
         response = JSON.parse(body)
         if response?.items
           image = msg.random response.items
@@ -75,6 +83,12 @@ imageMe = (msg, query, animated, faces, cb) ->
     msg.http('https://ajax.googleapis.com/ajax/services/search/images')
       .query(q)
       .get() (err, res, body) ->
+        if err
+          msg.send "Encountered an error :( #{err}"
+          return
+        if res.statusCode isnt 200
+          msg.send "Bad HTTP response :( #{res.statusCode}"
+          return
         images = JSON.parse(body)
         images = images.responseData?.results
         if images?.length > 0

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -40,7 +40,6 @@ imageMe = (msg, query, animated, faces, cb) ->
     googleApiKey = process.env.HUBOT_GOOGLE_API_KEY
     if !googleApiKey
       msg.robot.logger.error "Missing Google API key"
-      return
     q =
       q: query,
       searchType:'image',

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -1,6 +1,10 @@
 # Description:
 #   A way to interact with the Google Images API.
 #
+# Configuration
+#   HUBOT_GOOGLE_API_KEY - Your developer API key
+#   HUBOT_GOOGLE_CSE_ID - The ID of your Custom Search Engine
+#
 # Commands:
 #   hubot image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
 #   hubot animate me <query> - The same thing as `image me`, except adds a few parameters to try to return an animated GIF instead.
@@ -30,17 +34,41 @@ module.exports = (robot) ->
 imageMe = (msg, query, animated, faces, cb) ->
   cb = animated if typeof animated == 'function'
   cb = faces if typeof faces == 'function'
-  q = v: '1.0', rsz: '8', q: query, safe: 'active'
-  q.imgtype = 'animated' if typeof animated is 'boolean' and animated is true
-  q.imgtype = 'face' if typeof faces is 'boolean' and faces is true
-  msg.http('http://ajax.googleapis.com/ajax/services/search/images')
+  googleCseId = process.env.HUBOT_GOOGLE_CSE_ID
+  googleApiKey = process.env.HUBOT_GOOGLE_API_KEY
+  if googleCseId
+    q = q: query, searchType:'image', safe:'high',
+    fields:'items(link)',
+    cx: googleCseId, key: googleApiKey
+    if typeof animated is 'boolean' and animated is true
+      q.fileType = 'gif'
+      q.hq = 'animated'
+    q.imgType = 'face' if typeof faces is 'boolean' and faces is true
+    url = 'https://www.googleapis.com/customsearch/v1'
+  else
+    q = v: '1.0', rsz: '8', q: query, safe: 'active'
+    q.imgtype = 'animated' if typeof animated is 'boolean' and animated is true
+    q.imgtype = 'face' if typeof faces is 'boolean' and faces is true
+    url = 'https://ajax.googleapis.com/ajax/services/search/images'
+  msg.http(url)
     .query(q)
     .get() (err, res, body) ->
-      images = JSON.parse(body)
-      images = images.responseData?.results
+      response = JSON.parse(body)
+      images = response.responseData.results if response?.responseData
+      images = response.items if response?.items
       if images?.length > 0
         image = msg.random images
-        cb ensureImageExtension image.unescapedUrl
+        imgsrc = image.unescapedUrl
+        imgsrc = image.link if image.link
+        cb ensureImageExtension imgsrc
+      else
+        msg.send "Oops. I'm having trouble finding '#{query}'. Try again later."
+        ((error) ->
+          msg.robot.logger.error error.message
+          msg.robot.logger
+            .error "(see #{error.extendedHelp})" if error.extendedHelp
+        ) error for error in response.error.errors if response.error?.errors
+
 
 ensureImageExtension = (url) ->
   ext = url.split('.').pop()


### PR DESCRIPTION
If you set keys in the environment variables it will use your custom search engine. Other wise it uses the old API.

Note that the old Google search API has "safe=active" which is less restrictive than "safe=strict" on the new API. This can prevent some NSFW images which sneak through with the old API.