### PR TITLE
Added an option to use own mustachify

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Then add **hubot-google-images** to your `external-scripts.json`:
 ]
 ```
 
+## Using your own mustachify instance
+
+If you want to run you own instance instead of the default [mustachify](http://mustachify.me/), you can add `HUBOT_MUSTACHIFY_URL` to your environment variables and provide your own url. More info and the source code of mustachify can be found at [https://github.com/afeld/mustachio](https://github.com/afeld/mustachio)
+
 ## Sample Interaction
 
 ```

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -17,7 +17,8 @@ module.exports = (robot) ->
       msg.send url
 
   robot.respond /(?:mo?u)?sta(?:s|c)h(?:e|ify)?(?: me)? (.*)/i, (msg) ->
-    mustachify = "http://mustachify.me/rand?src="
+    mustacheBaseUrl = process.env.HUBOT_MUSTACHIFY_URL or "http://mustachify.me"
+    mustachify = "#{mustacheBaseUrl}/rand?src="
     imagery = msg.match[1]
 
     if imagery.match /^https?:\/\//i

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -17,8 +17,7 @@ module.exports = (robot) ->
       msg.send url
 
   robot.respond /(?:mo?u)?sta(?:s|c)h(?:e|ify)?(?: me)? (.*)/i, (msg) ->
-    type = Math.floor(Math.random() * 6)
-    mustachify = "http://mustachify.me/#{type}?src="
+    mustachify = "http://mustachify.me/rand?src="
     imagery = msg.match[1]
 
     if imagery.match /^https?:\/\//i

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -20,7 +20,7 @@ module.exports = (robot) ->
       msg.send url
 
   robot.respond /(?:mo?u)?sta(?:s|c)h(?:e|ify)?(?: me)? (.*)/i, (msg) ->
-    mustacheBaseUrl = process.env.HUBOT_MUSTACHIFY_URL.replace(/\/$/, '') or "http://mustachify.me"
+    mustacheBaseUrl = process.env.HUBOT_MUSTACHIFY_URL?.replace(/\/$/, '') or "http://mustachify.me"
     mustachify = "#{mustacheBaseUrl}/rand?src="
     imagery = msg.match[1]
 

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -1,6 +1,9 @@
 # Description:
 #   A way to interact with the Google Images API.
 #
+# Configuration:
+#   HUBOT_MUSTACHIFY_URL - Optional. Allow you to use your own mustachify instance.
+#
 # Commands:
 #   hubot image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
 #   hubot animate me <query> - The same thing as `image me`, except adds a few parameters to try to return an animated GIF instead.
@@ -17,7 +20,7 @@ module.exports = (robot) ->
       msg.send url
 
   robot.respond /(?:mo?u)?sta(?:s|c)h(?:e|ify)?(?: me)? (.*)/i, (msg) ->
-    mustacheBaseUrl = process.env.HUBOT_MUSTACHIFY_URL or "http://mustachify.me"
+    mustacheBaseUrl = process.env.HUBOT_MUSTACHIFY_URL.replace(/\/$/, '') or "http://mustachify.me"
     mustachify = "#{mustacheBaseUrl}/rand?src="
     imagery = msg.match[1]
 


### PR DESCRIPTION
Since the real mustachify seems to always be under heavy load, I added an option to pass your own mustache url if you deploy your own mustachify. It also include the fixes made in #5 (since they affect the same lines and I didn't think to start clean before doing the second PR.