### PR TITLE
Remove unnecessary typeof check.

### DIFF
--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -52,10 +52,10 @@ imageMe = (msg, query, animated, faces, cb) ->
       fields:'items(link)',
       cx: googleCseId,
       key: googleApiKey
-    if typeof animated is 'boolean' and animated is true
+    if animated is true
       q.fileType = 'gif'
       q.hq = 'animated'
-    if typeof faces is 'boolean' and faces is true
+    if faces is true
       q.imgType = 'face'
     url = 'https://www.googleapis.com/customsearch/v1'
     msg.http(url)


### PR DESCRIPTION
This double checks the datatype, which is unnecessary.

~~~ coffee
if typeof animated is 'boolean' and animated is true
  q.imgtype = 'animated'
~~~

~~~ javascript
if (typeof animated === 'boolean' && animated === true) {
  q.imgtype = 'animated';
}
~~~