### PR TITLE
Adding option to use Giphy as a source for animated images.

### DIFF
--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -5,7 +5,7 @@
 #   HUBOT_GOOGLE_CSE_KEY - Your Google developer API key
 #   HUBOT_GOOGLE_CSE_ID - The ID of your Custom Search Engine
 #   HUBOT_MUSTACHIFY_URL - Optional. Allow you to use your own mustachify instance.
-#   HUBOT_USE_GIPHY - If GOOGLE_CSE_* aren't set, use giphy for animated images (issue #10)
+#   HUBOT_GIPHY_KEY - If GOOGLE_CSE_* aren't set, use giphy for animated images (issue #10)
 #
 # Commands:
 #   hubot image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
@@ -88,12 +88,13 @@ imageMe = (msg, query, animated, faces, cb) ->
     use_giphy = false
 
     if typeof animated is 'boolean' and animated is true
-      use_giphy = (process.env.HUBOT_USE_GIPHY == 'true')
+      giphy_key = (process.env.HUBOT_GIPHY_KEY)
+      use_giphy = (typeof giphy_key is 'string' and giphy_key.length > 0)
       if typeof use_giphy is 'boolean' and use_giphy is true
         url = 'http://api.giphy.com/v1/gifs/search'
         q = 
           q: query
-          api_key: 'dc6zaTOxFJmzC'
+          api_key: giphy_key
           limit: 100
 
     msg.http(url)

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -6,6 +6,7 @@
 #   HUBOT_GOOGLE_CSE_ID - The ID of your Custom Search Engine
 #   HUBOT_MUSTACHIFY_URL - Optional. Allow you to use your own mustachify instance.
 #   HUBOT_GIPHY_KEY - If GOOGLE_CSE_* aren't set, use giphy for animated images (issue #10)
+#   HUBOT_GIPHY_RATING - can be one of 'y', 'g', 'pg', 'pg-13' or 'r'
 #
 # Commands:
 #   hubot image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
@@ -92,10 +93,17 @@ imageMe = (msg, query, animated, faces, cb) ->
       use_giphy = (typeof giphy_key is 'string' and giphy_key.length > 0)
       if typeof use_giphy is 'boolean' and use_giphy is true
         url = 'http://api.giphy.com/v1/gifs/search'
+        rating = process.env.HUBOT_GIPHY_RATING
+        if rating and rating.length == 0
+          rating = 'g'
+        else
+          if (rating != 'y') and (rating != 'g') and (rating != 'pg') and (rating != 'pg-13') and (rating != 'r')
+            rating = 'g'
         q = 
           q: query
           api_key: giphy_key
           limit: 100
+          rating: rating
 
     msg.http(url)
       .query(q)

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -128,7 +128,7 @@ imageMe = (msg, query, animated, faces, cb) ->
           msg.send "Sorry, I found no results for '#{query}'."
 
         if use_giphy
-          msg.send "(fetched from giphy.com)"
+          msg.send "Powered by Giphy"
 
 ensureImageExtension = (url) ->
   ext = url.split('.').pop()

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -94,7 +94,7 @@ imageMe = (msg, query, animated, faces, cb) ->
       if typeof use_giphy is 'boolean' and use_giphy is true
         url = 'http://api.giphy.com/v1/gifs/search'
         rating = process.env.HUBOT_GIPHY_RATING
-        if rating and rating.length == 0
+        if !rating or rating.length == 0
           rating = 'g'
         else
           rating = rating.toLowerCase()

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -97,6 +97,7 @@ imageMe = (msg, query, animated, faces, cb) ->
         if rating and rating.length == 0
           rating = 'g'
         else
+          rating = rating.toLowerCase()
           if (rating != 'y') and (rating != 'g') and (rating != 'pg') and (rating != 'pg-13') and (rating != 'r')
             rating = 'g'
         q = 

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -127,6 +127,9 @@ imageMe = (msg, query, animated, faces, cb) ->
         else
           msg.send "Sorry, I found no results for '#{query}'."
 
+        if use_giphy
+          msg.send "(fetched from giphy.com)"
+
 ensureImageExtension = (url) ->
   ext = url.split('.').pop()
   if /(png|jpe?g|gif)/i.test(ext)


### PR DESCRIPTION
To use this patch, add a new environment variable called HUBOT_USE_GIPHY and set its value to "true". If you use "animate me" and the env var is set, giphy will be used. If you use "image me" google will be used whether or not HUBOT_USE_GIPHY is set.

Docs for the Giphy API: https://github.com/giphy/GiphyAPI#search-endpoint