### PR TITLE
Add "tbs" parameter to CSE for better animation selection

### DIFF
--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -55,6 +55,7 @@ imageMe = (msg, query, animated, faces, cb) ->
     if animated is true
       q.fileType = 'gif'
       q.hq = 'animated'
+      q.tbs = 'itp:animated'
     if faces is true
       q.imgType = 'face'
     url = 'https://www.googleapis.com/customsearch/v1'


### PR DESCRIPTION
Undocumented, but pulled from the standard web interface
parameters and _seems_ to return animated images more
consistently.

Attempts to resolve #13.