### PR TITLE
Make giphy results more animated.

### DIFF
--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -72,7 +72,7 @@ imageMe = (msg, query, animated, faces, cb) ->
         if response?.items
           image = msg.random response.items
           if animated
-            image.link = image.link.replace(/(giphy\.com\/.*)\/.+_s.gif$/, '\\1/giphy.gif')
+            image.link = image.link.replace(/(giphy\.com\/.*)\/.+_s.gif$/, '$1/giphy.gif')
           cb ensureImageExtension image.link
         else
           msg.send "Oops. I had trouble searching '#{query}'. Try later."

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -72,7 +72,7 @@ imageMe = (msg, query, animated, faces, cb) ->
         if response?.items
           image = msg.random response.items
           if animated
-            image.link = image.link.replace(/(giphy\.com\/.*\/)[^\/]+_s.gif$/, '\\1/giphy.gif')
+            image.link = image.link.replace(/(giphy\.com\/.*)\/.+_s.gif$/, '\\1/giphy.gif')
           cb ensureImageExtension image.link
         else
           msg.send "Oops. I had trouble searching '#{query}'. Try later."

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -71,6 +71,8 @@ imageMe = (msg, query, animated, faces, cb) ->
         response = JSON.parse(body)
         if response?.items
           image = msg.random response.items
+          if animated
+            image.link = image.link.replace(/(giphy\.com\/.*\/)[^\/]+_s.gif$/, '\\1/giphy.gif')
           cb ensureImageExtension image.link
         else
           msg.send "Oops. I had trouble searching '#{query}'. Try later."


### PR DESCRIPTION
Giphy will sometimes list preview images in the Google results. These end in something like `/200_s.gif` you can get the animated version by changing the filename to giphy.gif. 

The regex matches URLS that have `giphy.com` at the beginning and end with `_s.gif`; replaces the last part with `/giphy.gif`