### PR TITLE
Respond to any chat that starts with `image me` or `animate me`

### DIFF
--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -13,6 +13,14 @@
 #   hubot mustache me <query> - Searches Google Images for the specified query and mustaches it.
 
 module.exports = (robot) ->
+  robot.hear /^image me (.*)/i, (msg) ->
+    imageMe msg, msg.match[1], (url) ->
+      msg.send url
+
+  robot.hear /^animate me (.*)/i, (msg) ->
+    imageMe msg, msg.match[1], true, (url) ->
+      msg.send url
+
   robot.respond /(image|img)( me)? (.*)/i, (msg) ->
     imageMe msg, msg.match[3], (url) ->
       msg.send url


### PR DESCRIPTION
Shortcut to get hubot to display an image without specifically calling the bot by name.  `image me` or `animate me` must be at the start of the line and aliases are not used to minimize chance of an unintentional trigger.

I've been using bots with this style of image triggering and haven't run into unintentional triggering.  If using `.hear` by default isn't wanted, I could pretty easily change this to be disabled by default but could be enabled with an environment variable.