### PR TITLE
Make the hear version consistent w/ respond

### DIFF
--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -26,7 +26,7 @@ module.exports = (robot) ->
 
   # pro feature, not added to docs since you can't conditionally document commands
   if process.env.HUBOT_GOOGLE_IMAGES_HEAR?
-    robot.hear /^image me (.*)/i, (msg) ->
+    robot.hear /^(image|img) me (.*)/i, (msg) ->
       imageMe msg, msg.match[1], (url) ->
         msg.send url
 


### PR DESCRIPTION
Otherwise, you can `@hubot image me` or `@hubot img me`, and `image me`, but not `img me`, which is the most commonly used variation.

Would love to see this ship out as 0.2.4 ASAP!