### PR TITLE
More robust regex

### DIFF
--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -16,25 +16,25 @@
 
 module.exports = (robot) ->
 
-  robot.respond /(image|img)( me)? (.*)/i, (msg) ->
+  robot.respond /(image|img)( me)? (.+)/i, (msg) ->
     imageMe msg, msg.match[3], (url) ->
       msg.send url
 
-  robot.respond /animate( me)? (.*)/i, (msg) ->
+  robot.respond /animate( me)? (.+)/i, (msg) ->
     imageMe msg, msg.match[2], true, (url) ->
       msg.send url
 
   # pro feature, not added to docs since you can't conditionally document commands
   if process.env.HUBOT_GOOGLE_IMAGES_HEAR?
-    robot.hear /^image me (.*)/i, (msg) ->
+    robot.hear /^image me (.+)/i, (msg) ->
       imageMe msg, msg.match[1], (url) ->
         msg.send url
 
-    robot.hear /^animate me (.*)/i, (msg) ->
+    robot.hear /^animate me (.+)/i, (msg) ->
       imageMe msg, msg.match[1], true, (url) ->
         msg.send url
 
-  robot.respond /(?:mo?u)?sta(?:s|c)h(?:e|ify)?(?: me)? (.*)/i, (msg) ->
+  robot.respond /(?:mo?u)?sta(?:s|c)h(?:e|ify)?(?: me)? (.+)/i, (msg) ->
     mustacheBaseUrl =
       process.env.HUBOT_MUSTACHIFY_URL?.replace(/\/$/, '') or
       "http://mustachify.me"


### PR DESCRIPTION
The regex should not match `@hubot img me ` (trailing space but no object). This may never happen, but if it does you get the error: `Oops. I had trouble searching ''. Try later.`