### PR TITLE
Fix hear-based img me matching

### DIFF
--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -27,7 +27,7 @@ module.exports = (robot) ->
   # pro feature, not added to docs since you can't conditionally document commands
   if process.env.HUBOT_GOOGLE_IMAGES_HEAR?
     robot.hear /^(image|img) me (.+)/i, (msg) ->
-      imageMe msg, msg.match[1], (url) ->
+      imageMe msg, msg.match[2], (url) ->
         msg.send url
 
     robot.hear /^animate me (.+)/i, (msg) ->


### PR DESCRIPTION
Courtesy of my addition of the shorthand in 10f9c36, it was now using either `image` or `img` as its matching item to search for. Derp.