### PR TITLE
Add fallback for Missing Google Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # hubot-google-images
 
-A hubot script that interacts with the Google Images API for greater productivity and lulz.
+A hubot script that interacts with the Google Custom Search API for greater
+productivity and lulz.
 
 See [`src/google-images.coffee`](src/google-images.coffee) for full documentation.
 
@@ -21,13 +22,9 @@ Then add **hubot-google-images** to your `external-scripts.json`:
 ## Configuration
 
 ### Custom Search Engine
-Set environment variables `HUBOT_GOOGLE_CSE_ID` and `HUBOT_GOOGLE_CSE_KEY`
-to use the [Google Custom Search API](https://developers.google.com/custom-search/docs/overview)
-instead of the deprecated image search API.
-
-You might want to use the custom search API if you have concerns about
-seeing NSFW images. The old Google image search API only has `safe=active`
-which is not as strict as `safe=strict` on the new API.
+Google no longer offers an unregistered image search API. You must set up a
+[Google Custom Search API](https://developers.google.com/custom-search/docs/overview) and set
+the environment variables `HUBOT_GOOGLE_CSE_ID` and `HUBOT_GOOGLE_CSE_KEY`.
 
 The Custom Search API provides up to [100 search queries per day](https://developers.google.com/custom-search/json-api/v1/overview) for free.
 If you need more than that you'll have to pay.

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -7,7 +7,7 @@
 #   HUBOT_MUSTACHIFY_URL - Optional. Allow you to use your own mustachify instance.
 #   HUBOT_GOOGLE_IMAGES_HEAR - Optional. If set, bot will respond to any line that begins with "image me" or "animate me" without needing to address the bot directly
 #   HUBOT_GOOGLE_SAFE_SEARCH - Optional. Search safety level.
-#   HUBOT_GOOGLE_IMAGES_FALLBACK - The URL of an image to show when API fails.
+#   HUBOT_GOOGLE_IMAGES_FALLBACK - The URL to use when API fails. `{q}` will be replaced with the query string.
 #
 # Commands:
 #   hubot image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
@@ -108,6 +108,7 @@ deprecatedImage = (msg, query, animated, faces, cb) ->
   # Show a fallback image
   imgUrl = process.env.HUBOT_GOOGLE_IMAGES_FALLBACK ||
     'http://i.imgur.com/CzFTOkI.png'
+  imgUrl = imgUrl.replace(/\{q\}/, encodeURIComponent(query))
   cb ensureResult(imgUrl, animated)
 
 # Forces giphy result to use animated version

--- a/src/google-images.coffee
+++ b/src/google-images.coffee
@@ -7,6 +7,7 @@
 #   HUBOT_MUSTACHIFY_URL - Optional. Allow you to use your own mustachify instance.
 #   HUBOT_GOOGLE_IMAGES_HEAR - Optional. If set, bot will respond to any line that begins with "image me" or "animate me" without needing to address the bot directly
 #   HUBOT_GOOGLE_SAFE_SEARCH - Optional. Search safety level.
+#   HUBOT_GOOGLE_IMAGES_FALLBACK - The URL of an image to show when API fails.
 #
 # Commands:
 #   hubot image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
@@ -99,37 +100,15 @@ imageMe = (msg, query, animated, faces, cb) ->
               .error "(see #{error.extendedHelp})" if error.extendedHelp
           ) error for error in response.error.errors if response.error?.errors
   else
+    msg.send "Google Image Search API is not longer available. " +
+      "Please setup up Custom Search Engine API."
     deprecatedImage(msg, query, animated, faces, cb)
 
 deprecatedImage = (msg, query, animated, faces, cb) ->
-  # Using deprecated Google image search API
-  q =
-    v: '1.0'
-    rsz: '8'
-    q: query
-    safe: process.env.HUBOT_GOOGLE_SAFE_SEARCH || 'active'
-  if animated is true
-    q.as_filetype = 'gif'
-    q.q += ' animated'
-  if faces is true
-    q.as_filetype = 'jpg'
-    q.imgtype = 'face'
-  msg.http('https://ajax.googleapis.com/ajax/services/search/images')
-    .query(q)
-    .get() (err, res, body) ->
-      if err
-        msg.send "Encountered an error :( #{err}"
-        return
-      if res.statusCode isnt 200
-        msg.send "Bad HTTP response :( #{res.statusCode}"
-        return
-      images = JSON.parse(body)
-      images = images.responseData?.results
-      if images?.length > 0
-        image = msg.random images
-        cb ensureResult(image.unescapedUrl, animated)
-      else
-        msg.send "Sorry, I found no results for '#{query}'."
+  # Show a fallback image
+  imgUrl = process.env.HUBOT_GOOGLE_IMAGES_FALLBACK ||
+    'http://i.imgur.com/CzFTOkI.png'
+  cb ensureResult(imgUrl, animated)
 
 # Forces giphy result to use animated version
 ensureResult = (url, animated) ->


### PR DESCRIPTION
Address #29 by showing a message and a fallback image.

Google Image Search API is not longer available. Please setup up Custom Search Engine API.
![No api](http://i.imgur.com/CzFTOkI.png)

You can provide a different fallback URL by defining the environment variable HUBOT_GOOGLE_IMAGES_FALLBACK. If you put `{q}` in the URL it will be replaced by the URL escaped query string.  (for example `http://placehold.it/480x150?text={q}`)